### PR TITLE
[HCR-184] Batch Layer S3 Sink 커넥터 설정

### DIFF
--- a/kafka-connect/README.md
+++ b/kafka-connect/README.md
@@ -1,0 +1,32 @@
+# Kafka Connect S3 Sink 설정
+
+커넥터 JSON에 S3 버킷/리전이 환경변수 플레이스홀더로 되어 있습니다.  
+등록 전에 `S3_BUCKET_NAME`, `AWS_REGION`을 설정한 뒤 치환해서 사용하세요.
+
+## 환경변수
+
+| 변수 | 설명 | 예시 |
+|------|------|------|
+| `S3_BUCKET_NAME` | S3 버킷 이름 | `my-logs-bucket` |
+| `AWS_REGION` | S3 리전 | `ap-northeast-2` |
+
+## 커넥터 등록 예시
+
+```bash
+export S3_BUCKET_NAME=your-bucket-name
+export AWS_REGION=ap-northeast-2
+envsubst < s3-sink-connector-jsonl.gz.json | curl -s -X POST http://<connect-host>:8083/connectors \
+  -H "Content-Type: application/json" \
+  -d @-
+```
+
+또는 치환된 파일을 임시로 만든 뒤 POST:
+
+```bash
+export S3_BUCKET_NAME=your-bucket-name
+export AWS_REGION=ap-northeast-2
+envsubst < s3-sink-connector-jsonl.gz.json > /tmp/connector.json
+curl -s -X POST http://<connect-host>:8083/connectors \
+  -H "Content-Type: application/json" \
+  -d @/tmp/connector.json
+```

--- a/kafka-connect/README.md
+++ b/kafka-connect/README.md
@@ -7,25 +7,33 @@
 
 | 변수 | 설명 | 예시 |
 |------|------|------|
+| `CONNECTOR_FILE` | 등록할 커넥터 JSON 파일명 | `s3-sink-connector-jsonl.gz.json` 또는 `s3-sink-connector-parquet.json` |
 | `S3_BUCKET_NAME` | S3 버킷 이름 | `my-logs-bucket` |
 | `AWS_REGION` | S3 리전 | `ap-northeast-2` |
 
 ## 커넥터 등록 예시
 
+두 커넥터 모두 같은 방식으로 등록할 수 있습니다. `CONNECTOR_FILE`만 바꿔서 사용하세요.
+
 ```bash
+# CONNECTOR_FILE은 s3-sink-connector-jsonl.gz.json 또는 s3-sink-connector-parquet.json 중 하나로 설정
+export CONNECTOR_FILE=s3-sink-connector-jsonl.gz.json
 export S3_BUCKET_NAME=your-bucket-name
 export AWS_REGION=ap-northeast-2
-envsubst < s3-sink-connector-jsonl.gz.json | curl -s -X POST http://<connect-host>:8083/connectors \
+
+envsubst < $CONNECTOR_FILE | curl -s -X POST http://<connect-host>:8083/connectors \
   -H "Content-Type: application/json" \
   -d @-
 ```
 
-또는 치환된 파일을 임시로 만든 뒤 POST:
+치환된 내용을 임시 파일로 만든 뒤 POST하는 방식:
 
 ```bash
+export CONNECTOR_FILE=s3-sink-connector-parquet.json
 export S3_BUCKET_NAME=your-bucket-name
 export AWS_REGION=ap-northeast-2
-envsubst < s3-sink-connector-jsonl.gz.json > /tmp/connector.json
+
+envsubst < $CONNECTOR_FILE > /tmp/connector.json
 curl -s -X POST http://<connect-host>:8083/connectors \
   -H "Content-Type: application/json" \
   -d @/tmp/connector.json

--- a/kafka-connect/s3-sink-connector-jsonl.gz.json
+++ b/kafka-connect/s3-sink-connector-jsonl.gz.json
@@ -11,7 +11,7 @@
 
 
     "flush.size": "500",
-    "rotate.interval.ms": "5000",
+    "rotate.interval.ms": "300000",
 
     "storage.class": "io.confluent.connect.s3.storage.S3Storage",
     "format.class": "io.confluent.connect.s3.format.json.JsonFormat",

--- a/kafka-connect/s3-sink-connector-jsonl.gz.json
+++ b/kafka-connect/s3-sink-connector-jsonl.gz.json
@@ -5,8 +5,8 @@
     "tasks.max": "1",
     "topics": "client-event-logs",
 
-    "s3.region": "ap-northeast-2",
-    "s3.bucket.name": "holliverse-dev-logs-test",
+    "s3.region": "${AWS_REGION}",
+    "s3.bucket.name": "${S3_BUCKET_NAME}",
     "s3.part.size": "5242880",
 
 

--- a/kafka-connect/s3-sink-connector-jsonl.gz.json
+++ b/kafka-connect/s3-sink-connector-jsonl.gz.json
@@ -1,0 +1,29 @@
+{
+  "name": "s3-sink-client-event-logs-jsonl",
+  "config": {
+    "connector.class": "io.confluent.connect.s3.S3SinkConnector",
+    "tasks.max": "1",
+    "topics": "client-event-logs",
+
+    "s3.region": "ap-northeast-2",
+    "s3.bucket.name": "holliverse-dev-logs-test",
+    "s3.part.size": "5242880",
+
+
+    "flush.size": "500",
+    "rotate.interval.ms": "5000",
+
+    "storage.class": "io.confluent.connect.s3.storage.S3Storage",
+    "format.class": "io.confluent.connect.s3.format.json.JsonFormat",
+    "compression.type": "gzip",
+
+    "partitioner.class": "io.confluent.connect.storage.partitioner.TimeBasedPartitioner",
+    "timestamp.extractor": "RecordField",
+    "timestamp.field": "timestamp",
+    "path.format": "'events/raw/dt='YYYY-MM-dd'/hour='HH",
+    "partition.duration.ms": "3600000",
+
+    "locale": "ko_KR",
+    "timezone": "UTC"
+  }
+}

--- a/kafka-connect/s3-sink-connector-parquet.json
+++ b/kafka-connect/s3-sink-connector-parquet.json
@@ -10,7 +10,7 @@
     "s3.part.size": "5242880",
 
     "flush.size": "500",
-    "rotate.interval.ms": "5000",
+    "rotate.interval.ms": "300000",
 
     "storage.class": "io.confluent.connect.s3.storage.S3Storage",
     "format.class": "io.confluent.connect.s3.format.parquet.ParquetFormat",

--- a/kafka-connect/s3-sink-connector-parquet.json
+++ b/kafka-connect/s3-sink-connector-parquet.json
@@ -5,8 +5,8 @@
     "tasks.max": "1",
     "topics": "client-event-logs",
 
-    "s3.region": "ap-northeast-2",
-    "s3.bucket.name": "holliverse-dev-logs-test",
+    "s3.region": "${AWS_REGION}",
+    "s3.bucket.name": "${S3_BUCKET_NAME}",
     "s3.part.size": "5242880",
 
     "flush.size": "500",

--- a/kafka-connect/s3-sink-connector-parquet.json
+++ b/kafka-connect/s3-sink-connector-parquet.json
@@ -1,0 +1,28 @@
+{
+  "name": "s3-sink-client-event-logs-parquet",
+  "config": {
+    "connector.class": "io.confluent.connect.s3.S3SinkConnector",
+    "tasks.max": "1",
+    "topics": "client-event-logs",
+
+    "s3.region": "ap-northeast-2",
+    "s3.bucket.name": "holliverse-dev-logs-test",
+    "s3.part.size": "5242880",
+
+    "flush.size": "500",
+    "rotate.interval.ms": "5000",
+
+    "storage.class": "io.confluent.connect.s3.storage.S3Storage",
+    "format.class": "io.confluent.connect.s3.format.parquet.ParquetFormat",
+    "parquet.codec": "snappy",
+
+    "partitioner.class": "io.confluent.connect.storage.partitioner.TimeBasedPartitioner",
+    "timestamp.extractor": "RecordField",
+    "timestamp.field": "timestamp",
+    "path.format": "'logs/'YYYY-MM-dd'/HH'",
+    "partition.duration.ms": "3600000",
+
+    "locale": "ko_KR",
+    "timezone": "UTC"
+  }
+}

--- a/kafka-connect/s3-sink-connector-parquet.json
+++ b/kafka-connect/s3-sink-connector-parquet.json
@@ -19,7 +19,7 @@
     "partitioner.class": "io.confluent.connect.storage.partitioner.TimeBasedPartitioner",
     "timestamp.extractor": "RecordField",
     "timestamp.field": "timestamp",
-    "path.format": "'logs/'YYYY-MM-dd'/HH'",
+    "path.format": "'events/raw/dt='YYYY-MM-dd'/hour='HH",
     "partition.duration.ms": "3600000",
 
     "locale": "ko_KR",

--- a/src/main/java/com/holliverse/logserver/config/KafkaSpeedConsumerConfig.java
+++ b/src/main/java/com/holliverse/logserver/config/KafkaSpeedConsumerConfig.java
@@ -16,7 +16,6 @@ import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
-import org.springframework.kafka.listener.ContainerProperties;
 
 @Slf4j
 @Configuration

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,3 +1,4 @@
+# 로컬 기본값 사용. 운영 시 환경변수로 덮어씀.
 spring:
   application:
     name: log-server
@@ -11,13 +12,13 @@ app:
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
     topics:
-      client-events: client-event-logs
-      error: error-logs
+      client-events: ${KAFKA_TOPIC_CLIENT_EVENTS:client-event-logs}
+      error: ${KAFKA_TOPIC_ERROR:error-logs}
     groups:
-      speed: speed-layer-group
+      speed: ${KAFKA_GROUP_SPEED:speed-layer-group}
     listener:
-      max-poll-records: 1
+      max-poll-records: ${KAFKA_MAX_POLL_RECORDS:1}
       ack-mode: RECORD
     producer:
-      dlq-acks: all
-      dlq-retries: 3
+      dlq-acks: ${KAFKA_DLQ_ACKS:all}
+      dlq-retries: ${KAFKA_DLQ_RETRIES:3}


### PR DESCRIPTION
## 📝작업 내용
<!-- 작업한 내용들 명시 -->
## Summary

- **Speed Layer**: `client-event-logs` 토픽에서 **`click_product_detail` 이벤트만** 필터링해 Redis ZSET 2개(recent_views, tag_scores)에 적재하는 Spring Boot Consumer 구현.
- **Batch Layer**: ECS에서 사용할 Kafka Connect S3 Sink 커넥터 설정 2종(JSONL.gz, Parquet) 추가.
- Kafka/Redis/커넥터 설정을 `app.kafka.*` 기반으로 정리하고, DLQ 및 AckMode Enum 반영.


<br/>

## 👀변경 사항
<!-- 팀원들이 알아야할 코드 , 설정, 구조등 변경을 명시 -->
## 주요 동작 요약

- **RecordFilterStrategy**: 리스너 진입 전에 `event_name == "click_product_detail"` 인 메시지만 통과, 나머지는 폐기.
- **Redis**:  
  - `user:{member_id}:recent_views` — ZADD(타임스탬프, JSON) + ZREMRANGEBYRANK로 최대 30개.  
  - `user:{member_id}:tag_scores` — event_properties.tags 배열 기준 ZINCRBY +1.
- **DLQ**: 역직렬화/Redis 처리 실패 시 원본 페이로드를 `error-logs` 토픽으로 전송 후 다음 메시지 계속 처리(무한 재시도 방지).
- **설정**: 토픽/그룹/ACK 등은 `application.yaml`의 `app.kafka.*`로 관리, SpEL `@kafkaAppProperties`로 주입.

---


## How to Test (로컬)

1. `docker compose -f docker-compose.local.yml up -d` (Kafka + Redis)
2. `./scripts/create-topics.sh --mode local`
3. `./gradlew bootRun`
4. `client-event-logs`에 `event_name: "click_product_detail"` 인 JSON 전송 후 Redis에서 `user:{member_id}:recent_views`, `user:{member_id}:tag_scores` 확인.
5. (선택) 잘못된 JSON 전송 → DLQ(`error-logs`)에 적재되는지 확인.

## 인프라 
- Batch Layer는 **ECS에서 Kafka Connect Worker**를 띄우고, 위 커넥터 JSON을 REST API로 등록해 사용.
- S3 버킷 / IAM Task Role(CloudWatch Logs 포함) / MSK 부트스트랩 주소는 운영 환경에서 별도 설정.


<br/>

## 🎫 Jira Ticket
- Jira Ticket: HCR-184

<br/>

## #️⃣관련 이슈

- closes #3 
